### PR TITLE
Improve SPR type narrowing

### DIFF
--- a/src/SPR.ts
+++ b/src/SPR.ts
@@ -14,12 +14,18 @@ import { zu } from '../mod.ts'
  * const fooDataOrErrors = result.data?.foo ?? result.error?.format().foo?._errors
  * ```
 */
-export function SPR<Input, Output> ( result: z.SafeParseReturnType<Input, Output> ): {
-    success: typeof result[ 'success' ]
-    data: z.SafeParseSuccess<Output>[ 'data' ] | undefined
-    error: z.SafeParseError<Input>[ 'error' ] | undefined
-} {
-    return result.success
-        ? { ...result, error: undefined }
-        : { ...result, data: undefined }
+export function SPR<Input, Output>(
+  result: z.SafeParseReturnType<Input, Output>
+):
+  | {
+      success: true;
+      data: z.SafeParseSuccess<Output>['data'];
+      error: undefined;
+    }
+  | {
+      success: false;
+      data: undefined;
+      error: z.SafeParseError<Input>['error'];
+    } {
+  return result.success ? { ...result, error: undefined } : { ...result, data: undefined };
 }


### PR DESCRIPTION
With this change, we preserve the fact that `data` and `error` will only exist when success matches their state.